### PR TITLE
Revert "Fix typo in README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ git clone git@github.com:alexpearce/dotfiles.git ~/Code/dotfiles
 The home-manager profile can then be built and activated:
 
 ```shell
-$ nix run home-manager/master --switch --flake ~/Code/dotfiles#apearwin
+$ nix run home-manager/master -- switch --flake ~/Code/dotfiles#apearwin
 ```
 
 To update dependencies:


### PR DESCRIPTION
Reverts alexpearce/dotfiles#5.

After setting up a fresh Nix install, I realised the original command was correct. The `--` with surrounding whitespace separates the arguments to `nix run` and those passed to the command to be run (`home-manager`).